### PR TITLE
Add a basic Gradle build setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,12 @@
+apply plugin: 'java'
+
+repositories {
+    mavenCentral()
+    maven { url 'https://hub.spigotmc.org/nexus/content/groups/public' }
+    maven { url 'https://maven.sk89q.com/repo/' }
+}
+
+dependencies {
+  compile group: 'org.bukkit', name: 'bukkit', version: '1.10-R0.1-SNAPSHOT' // Bukkit Core
+  compile group: 'com.sk89q.worldedit', name: 'worldedit-bukkit', version: '6.1.4-SNAPSHOT' // WorldEdit
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'BungeePortals'


### PR DESCRIPTION
This PR adds a gradle build setup, so an IDE isn't needed to compile. It includes deps for Bukkit 1.10 and WorldEdit. Similar to [this](https://github.com/YoFuzzy3/BungeePortals/pull/20/commits/4f6d622f8fc69a04eec6573a9716bce4ec4f3ad7) PR's commit, except it uses gradle instead of maven.
