### PR TITLE
Uses new WorldEdit Selection API + block names instead of outdated ids

### DIFF
--- a/src/net/yofuzzy3/BungeePortals/Listeners/EventListener.java
+++ b/src/net/yofuzzy3/BungeePortals/Listeners/EventListener.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 public class EventListener implements Listener {
 
@@ -53,5 +54,14 @@ public class EventListener implements Listener {
             }
         }
     }
+    
+    @EventHandler
+	public void onPlayerQuit(PlayerQuitEvent event) {
+		String playerName = event.getPlayer().getName();
+
+		if (this.statusData.containsKey(playerName)) {
+			this.statusData.remove(playerName);
+		}
+	}
 
 }


### PR DESCRIPTION
The current version doesn't work with the newer versions of WorldEdit because they changed how player selections are accessed. I updated it to work with the newest version. Bukkit also transitioned away from using id numbers for block materials. I replaced the id number in the selection command with the material's name. For example, instead of "bportals select 1" it would be "bportals select stone".